### PR TITLE
Add pytest tests for core modules and move manual scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cd src && python main.py "你的netlist.net" -o "輸出.xlsx"
 ## 📖 完整文檔
 
 - **[USER_MANUAL.md](USER_MANUAL.md)** - 完整使用說明書
-- **[test_comprehensive.py](test_comprehensive.py)** - 綜合功能測試
+- `examples/manual_tests/` - 手動測試與示範腳本
 
 ## 🛠️ 系統需求
 
@@ -50,11 +50,7 @@ cd src && python main.py "你的netlist.net" -o "輸出.xlsx"
 ## 🧪 測試驗證
 
 ```bash
-# 綜合功能測試
-python test_comprehensive.py
-
-# 或使用 pytest
-pytest tests/
+pytest
 ```
 
 ## 📈 版本歷史

--- a/examples/manual_tests/advanced_gui_demo.py
+++ b/examples/manual_tests/advanced_gui_demo.py
@@ -7,7 +7,7 @@ import sys
 import os
 
 # Add src to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 try:
     from src.advanced_gui import main

--- a/examples/manual_tests/comprehensive_demo.py
+++ b/examples/manual_tests/comprehensive_demo.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 # Add src to path
-sys.path.insert(0, str(Path(__file__).parent / 'src'))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src'))
 
 def quick_functionality_test():
     """Run a quick functionality test."""
@@ -17,7 +17,7 @@ def quick_functionality_test():
         from main import process_netlist_to_excel
         
         # Test with sample data
-        netlist_path = Path("tests/data/sample_netlist.net")
+        netlist_path = Path(__file__).resolve().parents[2] / "tests/data/sample_netlist.net"
         output_path = Path("quick_test_output.xlsx")
         
         if not netlist_path.exists():

--- a/examples/manual_tests/tooltip_visual_improvements_demo.py
+++ b/examples/manual_tests/tooltip_visual_improvements_demo.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 # Add src to path
-sys.path.insert(0, str(Path(__file__).parent / 'src'))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src'))
 
 def test_tooltip_themes():
     """Test different tooltip themes"""

--- a/examples/manual_tests/ui_improvements_demo.py
+++ b/examples/manual_tests/ui_improvements_demo.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 # Add src to path
-sys.path.insert(0, str(Path(__file__).parent / 'src'))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src'))
 
 def test_tooltip_system():
     """Test tooltip system functionality"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,10 @@ import yaml
 import pandas as pd
 from pathlib import Path
 from typing import Dict, Any
+import sys
+
+# Ensure the parent directory (containing ``src``) is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 @pytest.fixture(scope="session")
 def test_data_dir():

--- a/tests/core/test_net_classifier.py
+++ b/tests/core/test_net_classifier.py
@@ -1,36 +1,49 @@
-"""
-Unit tests for net classifier module.
-"""
-import pytest
+"""Unit tests for :mod:`src.core.net_classifier`."""
+from src.core.net_classifier import NetClassifier
 
 
 class TestNetClassifier:
     """Test cases for net classification functionality."""
-    
+
     def test_classify_i2c_nets(self, config_data):
-        """Test classification of I2C networks."""
-        pass
-    
+        """I2C related net names should be classified correctly."""
+        classifier = NetClassifier(config_data)
+        result = classifier.classify(["I2C_SCL", "I2C_SDA"])
+        assert result["I2C_SCL"]["signal_type"] == "I2C"
+        assert result["I2C_SDA"]["category"] == "Communication Interface"
+
     def test_classify_spi_nets(self, config_data):
-        """Test classification of SPI networks."""
-        pass
-    
+        """SPI nets should match the SPI rule."""
+        classifier = NetClassifier(config_data)
+        result = classifier.classify(["SPI_MOSI"])
+        assert result["SPI_MOSI"]["rule_matched"] == "SPI"
+
     def test_classify_rf_nets(self, config_data):
-        """Test classification of RF networks."""
-        pass
-    
+        """RF nets use the RF rule with category RF."""
+        classifier = NetClassifier(config_data)
+        result = classifier.classify(["RF_ANT1"])
+        assert result["RF_ANT1"]["category"] == "RF"
+
     def test_classify_unknown_nets(self, config_data):
-        """Test classification of unknown network types."""
-        pass
-    
+        """Unknown nets fall back to the default classification."""
+        classifier = NetClassifier(config_data)
+        result = classifier.classify(["UNKNOWN_NET"])
+        assert result["UNKNOWN_NET"]["category"] == "Other"
+
     def test_regex_pattern_matching(self, config_data):
-        """Test regex pattern matching for net classification."""
-        pass
-    
+        """Regex patterns should match even if keywords are absent."""
+        classifier = NetClassifier(config_data)
+        result = classifier.classify(["SCL_MAIN"])
+        assert result["SCL_MAIN"]["signal_type"] == "I2C"
+
     def test_keyword_matching(self, config_data):
-        """Test keyword matching for net classification."""
-        pass
-    
+        """Keyword matching should ignore case."""
+        classifier = NetClassifier(config_data)
+        result = classifier.classify(["rf_tx"])
+        assert result["rf_tx"]["category"] == "RF"
+
     def test_case_insensitive_matching(self, config_data):
-        """Test case insensitive matching."""
-        pass
+        """Classification should be case insensitive."""
+        classifier = NetClassifier(config_data)
+        result = classifier.classify(["spi_mosi"])
+        assert result["spi_mosi"]["signal_type"] == "SPI"

--- a/tests/core/test_netlist_parser.py
+++ b/tests/core/test_netlist_parser.py
@@ -1,34 +1,53 @@
-"""
-Unit tests for netlist parser module.
-"""
-import pytest
+"""Tests for :mod:`src.core.netlist_parser`."""
 from pathlib import Path
+
+from src.core.netlist_parser import NetlistParser
 
 
 class TestNetlistParser:
     """Test cases for netlist parsing functionality."""
-    
-    def test_parse_valid_netlist(self, sample_netlist_content):
-        """Test parsing a valid netlist file."""
-        # This test will be implemented once the netlist_parser module is created
-        pass
-    
-    def test_parse_empty_netlist(self, empty_netlist):
-        """Test parsing an empty netlist file."""
-        pass
-    
-    def test_parse_invalid_format(self, sample_invalid_netlist):
-        """Test parsing invalid netlist format should raise exception."""
-        pass
-    
+
+    def test_parse_valid_netlist(self, tmp_path, sample_netlist_content):
+        """Parser should return all net names from a valid file."""
+        netlist = tmp_path / "sample.net"
+        netlist.write_text(sample_netlist_content)
+        parser = NetlistParser()
+        nets = parser.parse(netlist)
+        assert "I2C_SCL" in nets and "RF_ANT1" in nets
+        assert len(nets) == 7
+
+    def test_parse_empty_netlist(self, tmp_path):
+        """Empty files result in no net names."""
+        netlist = tmp_path / "empty.net"
+        netlist.write_text("")
+        parser = NetlistParser()
+        assert parser.parse(netlist) == []
+
+    def test_parse_invalid_format(self, tmp_path, sample_invalid_netlist):
+        """Invalid formats simply produce an empty list."""
+        netlist = tmp_path / "invalid.net"
+        netlist.write_text(sample_invalid_netlist)
+        parser = NetlistParser()
+        assert parser.parse(netlist) == []
+
     def test_extract_net_names(self, sample_netlist_content):
-        """Test extraction of net names from netlist."""
-        pass
-    
-    def test_filter_excluded_components(self, sample_netlist_content):
-        """Test filtering of excluded component identifiers."""
-        pass
-    
-    def test_parse_large_netlist(self, large_netlist):
-        """Test parsing performance with large netlist files."""
-        pass
+        """Raw extraction should include all names before filtering."""
+        parser = NetlistParser()
+        names = parser._extract_net_names(sample_netlist_content)
+        assert "I2C_SCL" in names
+        assert "R123" not in names
+
+    def test_filter_excluded_components(self):
+        """Component references and numbers are removed."""
+        parser = NetlistParser()
+        names = ["R123", "TEST", "123", "NET1"]
+        filtered = parser._filter_excluded_names(names)
+        assert filtered == ["TEST", "NET1"]
+
+    def test_parse_large_netlist(self, tmp_path, large_netlist):
+        """Large netlists should be parsed completely."""
+        netlist = tmp_path / "large.net"
+        netlist.write_text(large_netlist)
+        parser = NetlistParser()
+        nets = parser.parse(netlist)
+        assert len(nets) == 1000

--- a/tests/core/test_rule_engine.py
+++ b/tests/core/test_rule_engine.py
@@ -1,36 +1,55 @@
-"""
-Unit tests for rule engine module.
-"""
-import pytest
+"""Tests for :mod:`src.core.rule_engine`."""
+from src.core.net_classifier import NetClassifier
+from src.core.rule_engine import RuleEngine
 
 
 class TestRuleEngine:
     """Test cases for layout rule engine functionality."""
-    
+
     def test_apply_i2c_rules(self, config_data):
-        """Test application of I2C layout rules."""
-        pass
-    
+        classifier = NetClassifier(config_data)
+        classified = classifier.classify(["I2C_SCL"])
+        engine = RuleEngine(config_data)
+        layout = engine.apply_rules(classified)
+        info = layout["I2C_SCL"]
+        assert info["impedance"] == "50 Ohm"
+        assert info["signal_type"] == "I2C"
+
     def test_apply_spi_rules(self, config_data):
-        """Test application of SPI layout rules."""
-        pass
-    
+        classifier = NetClassifier(config_data)
+        classified = classifier.classify(["SPI_CLK"])
+        engine = RuleEngine(config_data)
+        layout = engine.apply_rules(classified)
+        assert layout["SPI_CLK"]["description"].startswith("SPI")
+
     def test_apply_rf_rules(self, config_data):
-        """Test application of RF layout rules."""
-        pass
-    
-    def test_apply_default_rules(self, config_data):
-        """Test application of default rules for unknown types."""
-        pass
-    
+        classifier = NetClassifier(config_data)
+        classified = classifier.classify(["RF_TX1"])
+        engine = RuleEngine(config_data)
+        layout = engine.apply_rules(classified)
+        assert layout["RF_TX1"]["category"] == "RF"
+
+    def test_apply_default_rules(self):
+        classifier = NetClassifier()
+        classified = classifier.classify(["UNKNOWN_NET"])
+        engine = RuleEngine()
+        layout = engine.apply_rules(classified)
+        assert layout["UNKNOWN_NET"]["rule_matched"] == "default"
+        assert layout["UNKNOWN_NET"]["impedance"] == "50 Ohm"
+
     def test_rule_priority_handling(self, config_data):
-        """Test handling of rule priorities."""
-        pass
-    
+        classifier = NetClassifier(config_data)
+        classified = classifier.classify(["I2C_SCL"])
+        engine = RuleEngine(config_data)
+        layout = engine.apply_rules(classified)
+        assert layout["I2C_SCL"]["priority"] == classified["I2C_SCL"]["priority"]
+
     def test_custom_rule_application(self, config_data):
-        """Test application of custom user-defined rules."""
-        pass
-    
-    def test_rule_validation(self, config_data):
-        """Test validation of rule format and content."""
-        pass
+        engine = RuleEngine(config_data)
+        engine.add_custom_rule("CUSTOM", {"impedance": "75 Ohm", "description": "Custom"})
+        assert "CUSTOM" in engine.layout_rules
+
+    def test_rule_validation(self):
+        engine = RuleEngine()
+        assert engine.validate_rule_config({"impedance": "50 Ohm", "description": "desc"})
+        assert not engine.validate_rule_config({"impedance": "50 Ohm"})

--- a/tests/core/test_template_mapper.py
+++ b/tests/core/test_template_mapper.py
@@ -1,36 +1,52 @@
-"""
-Unit tests for template mapper module.
-"""
-import pytest
+"""Tests for :mod:`src.core.template_mapper`."""
+import pandas as pd
+
+from src.core.template_mapper import TemplateMapper
 
 
 class TestTemplateMapper:
     """Test cases for Excel template mapping functionality."""
-    
-    def test_map_to_standard_template(self, sample_excel_template, config_data):
-        """Test mapping data to standard Excel template."""
-        pass
-    
-    def test_map_to_custom_template(self, config_data):
-        """Test mapping data to custom template format."""
-        pass
-    
-    def test_column_mapping(self, sample_excel_template, config_data):
-        """Test correct column mapping."""
-        pass
-    
-    def test_data_type_conversion(self, config_data):
-        """Test proper data type conversion for Excel output."""
-        pass
-    
-    def test_template_validation(self, sample_excel_template):
-        """Test validation of template structure."""
-        pass
-    
-    def test_missing_columns_handling(self, config_data):
-        """Test handling of missing template columns."""
-        pass
-    
-    def test_excel_output_generation(self, sample_excel_template, config_data):
-        """Test generation of final Excel output."""
-        pass
+
+    def _sample_layout_data(self):
+        return {
+            "NET1": {
+                "category": "Communication Interface",
+                "signal_type": "I2C",
+                "impedance": "50 Ohm",
+                "description": "I2C line",
+                "width": "5 mil",
+                "length_limit": "6 inch",
+                "spacing": "3W spacing",
+                "shielding": "Ground guard",
+                "layer_stack": "Any",
+                "notes": "",
+                "priority": 1,
+            }
+        }
+
+    def test_map_to_standard_template(self, tmp_path, config_data):
+        mapper = TemplateMapper(config_data)
+        output = tmp_path / "out.xlsx"
+        result = mapper.map_to_template(self._sample_layout_data(), output_path=output)
+        assert result.exists()
+        df = pd.read_excel(result)
+        assert df["Net Name"].iloc[0] == "NET1"
+
+    def test_column_mapping(self, tmp_path, config_data):
+        mapper = TemplateMapper(config_data)
+        result = mapper.map_to_template(self._sample_layout_data(), output_path=tmp_path / "out.xlsx")
+        df = pd.read_excel(result)
+        assert list(df.columns)[:3] == ["Category", "Net Name", "Pin (MT7921)"]
+
+    def test_template_validation(self, sample_excel_template, config_data):
+        mapper = TemplateMapper(config_data)
+        assert mapper.validate_template(sample_excel_template)
+
+    def test_missing_columns_handling(self, mock_excel_file, config_data):
+        mapper = TemplateMapper(config_data)
+        assert not mapper.validate_template(mock_excel_file)
+
+    def test_excel_output_generation(self, tmp_path, config_data):
+        mapper = TemplateMapper(config_data)
+        path = mapper.map_to_template(self._sample_layout_data(), output_path=tmp_path / "out.xlsx")
+        assert path.exists()


### PR DESCRIPTION
## Summary
- implement real pytest unit tests for core modules: net classifier, netlist parser, rule engine, and template mapper
- move GUI and comprehensive test scripts into `examples/manual_tests` for manual execution
- update README and test configuration so pytest runs automatically

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7292714cc8321ab45d6ad1979e43f