### PR TITLE
Improve error handling for layout rule controller

### DIFF
--- a/src/controllers/layout_rule_controller.py
+++ b/src/controllers/layout_rule_controller.py
@@ -4,9 +4,13 @@ Layout Rule Controller for managing layout rule operations
 """
 
 from typing import List, Dict, Any, Optional
+import logging
 from PyQt5.QtCore import QObject, pyqtSignal
 
 from models.layout_rule_model import LayoutRuleModel
+
+
+logger = logging.getLogger(__name__)
 
 
 class LayoutRuleController(QObject):
@@ -20,6 +24,7 @@ class LayoutRuleController(QObject):
     ruleRemoved = pyqtSignal(str)       # rule name
     ruleModified = pyqtSignal(str)      # rule name
     ruleValidated = pyqtSignal(str, bool, list)  # rule name, success, errors
+    errorOccurred = pyqtSignal(str)     # error message
     
     def __init__(self, layout_rules: Dict[str, LayoutRuleModel]):
         super().__init__()
@@ -43,8 +48,10 @@ class LayoutRuleController(QObject):
             self.ruleAdded.emit(rule_name)
             return True
             
-        except Exception:
-            return False
+        except Exception as e:
+            logger.exception(f"Failed to add rule {rule_name}: {e}")
+            self.errorOccurred.emit(str(e))
+            raise
     
     def remove_rule(self, rule_name: str) -> bool:
         """Remove a layout rule"""

--- a/tests/controllers/test_layout_rule_controller.py
+++ b/tests/controllers/test_layout_rule_controller.py
@@ -1,0 +1,41 @@
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+from PyQt5.QtCore import QCoreApplication
+
+# Add src directory to path for model imports
+base_path = Path(__file__).resolve().parents[2] / "src"
+sys.path.append(str(base_path))
+
+# Import LayoutRuleController without triggering controllers package imports
+spec = importlib.util.spec_from_file_location(
+    "layout_rule_controller", base_path / "controllers" / "layout_rule_controller.py"
+)
+layout_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(layout_module)
+LayoutRuleController = layout_module.LayoutRuleController
+
+from models.layout_rule_model import LayoutRuleModel
+
+
+def test_add_rule_logs_and_raises(monkeypatch, caplog):
+    app = QCoreApplication.instance() or QCoreApplication([])
+    controller = LayoutRuleController({})
+    errors = []
+    controller.errorOccurred.connect(errors.append)
+
+    def fake_load_from_dict(self, name, data):
+        raise ValueError("bad data")
+
+    monkeypatch.setattr(LayoutRuleModel, "load_from_dict", fake_load_from_dict)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ValueError):
+            controller.add_rule("rule1", {"foo": "bar"})
+
+    assert errors and "bad data" in errors[0]
+    record = next(r for r in caplog.records if "Failed to add rule rule1" in r.getMessage())
+    assert record.exc_info is not None


### PR DESCRIPTION
## Summary
- Log exceptions in `LayoutRuleController.add_rule` with `logger.exception`
- Emit `errorOccurred` signal and re-raise non-recoverable errors
- Add unit test verifying errors are logged and propagated

## Testing
- `pytest tests/controllers/test_layout_rule_controller.py::test_add_rule_logs_and_raises -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7291cec748321af1fcfed7184237e