### PR TITLE
Replace prints with module-level logging

### DIFF
--- a/src/controllers/configuration_controller.py
+++ b/src/controllers/configuration_controller.py
@@ -8,6 +8,9 @@ from pathlib import Path
 from typing import List, Dict, Any, Optional
 from PyQt5.QtCore import QObject, pyqtSignal
 from PyQt5.QtWidgets import QMessageBox, QFileDialog
+import logging
+
+logger = logging.getLogger(__name__)
 
 from models.configuration_model import ConfigurationModel
 
@@ -76,7 +79,7 @@ class ConfigurationController(QObject):
             self.redo_stack.clear()
             
         except Exception as e:
-            print(f"Warning: Could not save state for undo: {e}")
+            logger.warning(f"Could not save state for undo: {e}")
     
     def load_config_file(self, config_path: Optional[Path] = None) -> bool:
         """

--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,8 @@ from typing import Optional
 import logging
 import sys
 
+logger = logging.getLogger(__name__)
+
 # Add src to path for imports
 # Handle both development and PyInstaller environments
 if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
@@ -72,7 +74,6 @@ def process_netlist_to_excel(netlist_path: Path,
     
     # Setup logging
     setup_logging(config_manager)
-    logger = logging.getLogger(__name__)
     
     logger.info("=== 阻抗控制佈局指南生成開始 ===")
     logger.info(f"處理 Netlist 檔案: {netlist_path}")
@@ -146,10 +147,10 @@ def main():
             output_path=args.output,
             config_path=args.config
         )
-        print(f"✅ 成功生成佈局指南: {output_file}")
-        
+        logger.info(f"✅ 成功生成佈局指南: {output_file}")
+
     except Exception as e:
-        print(f"❌ 錯誤: {str(e)}")
+        logger.error(f"❌ 錯誤: {str(e)}")
         sys.exit(1)
 
 

--- a/src/models/configuration_model.py
+++ b/src/models/configuration_model.py
@@ -8,6 +8,9 @@ import copy
 from pathlib import Path
 from typing import Dict, List, Any, Optional
 from PyQt5.QtCore import QObject, pyqtSignal
+import logging
+
+logger = logging.getLogger(__name__)
 
 from models.signal_rule_model import SignalRuleModel
 from models.layout_rule_model import LayoutRuleModel
@@ -55,9 +58,9 @@ class ConfigurationModel(QObject):
             if default_config_path.exists():
                 self.load_config(default_config_path)
             else:
-                print(f"Warning: Config file not found at {default_config_path}")
+                logger.warning(f"Config file not found at {default_config_path}")
         except Exception as e:
-            print(f"Warning: Could not load default config: {e}")
+            logger.warning(f"Could not load default config: {e}")
     
     def load_config(self, config_path: Path) -> bool:
         """
@@ -158,7 +161,7 @@ class ConfigurationModel(QObject):
             
         except Exception as e:
             error_msg = f"Error parsing configuration data: {str(e)}"
-            print(error_msg)
+            logger.error(error_msg)
             raise  # Re-raise the exception
     
     def _build_config_data(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- replace prints with logger calls in main, configuration model, and configuration controller
- expose module-level loggers so `setup_logging` controls output

## Testing
- `python src/main.py tests/data/sample_netlist.net -o /tmp/output.xlsx`
- `pytest`
- `python - <<'PY' ...` *(fails: ImportError: libGL.so.1)*


------
https://chatgpt.com/codex/tasks/task_e_68a729184c308321b51649ce105085b3